### PR TITLE
Added support for relative paths for :bower_target_path

### DIFF
--- a/lib/capistrano/tasks/bower.tasks
+++ b/lib/capistrano/tasks/bower.tasks
@@ -1,3 +1,5 @@
+require 'pathname'
+
 namespace :bower do
   desc <<-DESC
         Install the current Bower environment. The install command is executed \
@@ -11,7 +13,12 @@ namespace :bower do
     DESC
   task :install do
     on roles fetch(:bower_roles) do
-      within fetch(:bower_target_path, release_path) do
+      bower_install_path = fetch(:bower_target_path, release_path)
+      if not (Pathname.new bower_install_path).absolute?
+        bower_install_path = File.join(release_path, bower_install_path)
+      end
+      puts bower_install_path
+      within bower_install_path do
         execute :bower, "install",
           fetch(:bower_flags)
       end


### PR DESCRIPTION
I've added support for relative paths in :bower_target_path. 

Having it support only absolute paths doesn't quite work, since the value of _release_path_ (as in the example from the readme) changes during execution it is handy to just specify the relative path so that the correct value of _release_path_ is fetch when bower:install is invoked.

Since I am not a ruby developer I am sure there are better ways to achieve this. Feel free to reject the pull request and suggest a better way, I will try to fix it and resubmit as needed.
