### PR TITLE
Adds support for overriding bower binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Configurable options, shown here with defaults:
 set :bower_flags, '--quiet --config.interactive=false'
 set :bower_roles, :web
 set :bower_target_path, nil
+set :bower_bin, :bower
 ```
 
 If your bower.json is not in the root directory, set the directory with :bower_target_path. For example with Symfony2:
@@ -44,6 +45,12 @@ If your bower.json is not in the root directory, set the directory with :bower_t
 set :bower_flags, '--quiet --config.interactive=false'
 set :bower_roles, :web
 set :bower_target_path, "#{release_path}/web"
+```
+
+If your `bower` executable is not found in the default PATH by capistrano, set the `bower_bin` option. For example:
+
+```ruby
+set :bower_bin, '/usr/local/node/node-default/bin/bower'
 ```
 
 ## Contributing

--- a/lib/capistrano/tasks/bower.rake
+++ b/lib/capistrano/tasks/bower.rake
@@ -12,7 +12,7 @@ namespace :bower do
   task :install do
     on roles fetch(:bower_roles) do
       within fetch(:bower_target_path, release_path) do
-        execute :bower, "install",
+        execute fetch(:bower_bin), "install",
           fetch(:bower_flags)
       end
     end
@@ -26,5 +26,6 @@ namespace :load do
   task :defaults do
     set :bower_flags, '--quiet --config.interactive=false'
     set :bower_roles, :web
+    set :bower_bin, :bower
   end
 end


### PR DESCRIPTION
My environment doesn't find `bower` by default. I have to either add the node path to the environment manually, or override the path to executable (which is usually the option I prefer)
